### PR TITLE
Add gogs support squashed

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,6 +1,9 @@
 # Rename this file to config.ini
 
 [source]
+#for gogs support use:
+#system     = gogs
+system     = github
 server     = github.enterprise_dns.com
 repository = apple/myrepo
 username   = git.bot

--- a/gh-issues-import-ng.py
+++ b/gh-issues-import-ng.py
@@ -438,6 +438,8 @@ def import_issues(issues):
             new_issue['label_objects'] = []
             for issue_label in issue['labels']:
                 found_label = get_label_by_name(issue_label['name'])
+                if not found_label:
+                    found_label = get_label_by_name(issue_label['name'].lower())
                 if found_label:
                     new_issue['label_objects'].append(found_label)
                 else:

--- a/gh-issues-import-ng.py
+++ b/gh-issues-import-ng.py
@@ -29,14 +29,15 @@ class state:
 state.current = state.INITIALIZING
 
 http_error_messages = {}
-http_error_messages[401] = "ERROR: There was a problem during authentication.\nDouble check that your username and " \
-                           "password are correct, and that you have permission to read from or write to the specified" \
-                           " repositories."
-http_error_messages[403] = http_error_messages[401]     # Basically the same problem.
-                                                        # GitHub returns 403 instead to prevent abuse.
-http_error_messages[404] = "ERROR: Unable to find the specified repository.\nDouble check the spelling for the source" \
-                           " and target repositories. If either repository is private, make sure the specified user " \
-                           "is allowed access to it."
+http_error_messages[401] = "HTTP ERROR 401: There was a problem during authentication.\n" \
+                           "Double check that your username and password are correct, " \
+                           "and that you have permission to read from or write to the specified repositories."
+http_error_messages[403] = "HTTP ERROR 403: GitHub returns 403 to prevent abuse. " \
+                           "The server understood the request, but is refusing to fulfill it. " \
+                           "Authorization will not help and the request SHOULD NOT be repeated."
+http_error_messages[404] = "HTTP ERROR 404: Unable to find the specified repository.\n" \
+                           "Double check the spelling for the source and target repositories. " \
+                           "If either repository is private, make sure the specified user is allowed access to it."
 
 
 def init_config():

--- a/gh-issues-import-ng.py
+++ b/gh-issues-import-ng.py
@@ -152,6 +152,8 @@ def init_config():
         # if SOURCE server is not github.com, then assume ENTERPRISE github (yourdomain.com/api/v3...)
         if config.get(which, 'server') == "github.com":
             api_url = "https://api.github.com"
+        elif config.get(which, 'system') == "gogs":
+            api_url = "https://{}/api/v1".format(config.get(which, 'server'))
         else:
             api_url = "https://%s/api/v3" % config.get(which, 'server')
 
@@ -198,7 +200,12 @@ def init_config():
 
 def format_date(datestring):
     # The date comes from the API in ISO-8601 format
-    date = datetime.datetime.strptime(datestring, "%Y-%m-%dT%H:%M:%SZ")
+    format = "%Y-%m-%dT%H:%M:%SZ"
+    if config.get("source", "system") == "gogs":
+        datestring = datestring[:-3] + datestring[-2:]
+        #2016-11-02T13:36:53+0100
+        format = "%Y-%m-%dT%H:%M:%S%z"
+    date = datetime.datetime.strptime(datestring, format)
     date_format = config.get('format', 'date', fallback='%A %b %d, %Y at %H:%M GMT', raw=True)
     return date.strftime(date_format)
 
@@ -340,10 +347,16 @@ def import_comments(comments, issue_number):
     for comment in comments:
         template_data = {}
         template_data['user_name'] = comment['user']['login']
-        template_data['user_url'] = comment['user']['html_url']
+        if config.get("source", "system") == "gogs":
+            template_data['user_url'] = config.get("source", "url") + "/" + template_data['user_name']
+        else:
+            template_data['user_url'] = comment['user']['html_url']
         template_data['user_avatar'] = comment['user']['avatar_url']
         template_data['date'] = format_date(comment['created_at'])
-        template_data['url'] = comment['html_url']
+        if config.get("source", "system") == "gogs":
+            template_data['url'] = config.get("source", "url") + "/issues/" + str(comment['id'])
+        else:
+            template_data['url'] = comment['html_url']
         template_data['body'] = comment['body']
 
         comment['body'] = format_comment(template_data)
@@ -434,13 +447,20 @@ def import_issues(issues):
 
         template_data = {}
         template_data['user_name'] = issue['user']['login']
-        template_data['user_url'] = issue['user']['html_url']
+        if config.get("source", "system") == "gogs":
+            template_data['user_url'] = "https://" + config.get("source", "server") + "/" + template_data['user_name']
+        else:
+            template_data['user_url'] = issue['user']['html_url']
         template_data['user_avatar'] = issue['user']['avatar_url']
         template_data['date'] = format_date(issue['created_at'])
-        template_data['url'] = issue['html_url']
+        if config.get("source", "system") == "gogs":
+            template_data['url'] = "https://" + config.get("source", "server") + "/" + \
+                                   config.get("source", "repository") + "/issues/" + str(issue['number'])
+        else:
+            template_data['url'] = issue['html_url']
         template_data['body'] = issue['body']
 
-        if 'pull_request' in issue:
+        if 'pull_request' in issue.keys() and issue['pull_request'] is not None:
             if config.getboolean('settings', 'import-pulls'):
                 pull_request_ids.append(issue['id'])
                 if issue['pull_request']['html_url'] is not None:

--- a/gh-issues-import-ng.py
+++ b/gh-issues-import-ng.py
@@ -411,13 +411,6 @@ def import_issues(issues):
         elif issue['state'] == 'closed':
             closed_issue_ids.append(issue['id'])
 
-        # Temporary fix for marking closed issues
-        if issue['closed_at']:
-            if 'pull_request' in issue:
-                new_issue['title'] = "[PR][CLOSED] " + new_issue['title']
-            else:
-                new_issue['title'] = "[ISSUE][CLOSED] " + new_issue['title']
-
         if config.getboolean('settings', 'import-comments') and 'comments' in issue and issue['comments'] != 0:
             num_new_comments += int(issue['comments'])
             new_issue['comments'] = get_comments_on_issue('source', issue)


### PR DESCRIPTION
This introduces support for Gogs export/import using the Gogs API. The Gogs API however does not offer a full GitHub API feature set yet. Although its existing interfaces are the same.

Supported:
- Issues
- Labels

Not supported:
- Pull Requests

I imported [this repo](https://github.com/tklab-tud/ID2T) to GitHub from [here](https://git.tk.informatik.tu-darmstadt.de/SPIN/ID2T-toolkit). Feel free to check it out.

If you want to test it yourself, just use [try Gogs](https://try.gogs.io/).

p.s. On my last pull request you removed the signature from my commit. I'm assuming this was not on purpose, but I would appreciate it if you could avoid this in the future.